### PR TITLE
Add new Release

### DIFF
--- a/Controllers/ReleasesController.cs
+++ b/Controllers/ReleasesController.cs
@@ -1,0 +1,42 @@
+using System.Threading.Tasks;
+using AutoMapper;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using ReleaseNotes_WebAPI.Domain.Models;
+using ReleaseNotes_WebAPI.Domain.Services;
+using ReleaseNotes_WebAPI.Extensions;
+using ReleaseNotes_WebAPI.Resources;
+
+namespace ReleaseNotes_WebAPI.Controllers
+{
+    [Route("/api/[controller]")]
+    public class ReleasesController : Controller
+    {
+        private readonly IReleaseService _releaseService;
+        private readonly IMapper _mapper;
+
+        public ReleasesController(IReleaseService releaseService, IMapper mapper)
+        {
+            _releaseService = releaseService;
+            _mapper = mapper;
+        }
+        
+        [HttpPost]
+        [Authorize(Roles="Administrator")]
+        public async Task<IActionResult> PostAsync([FromBody] SaveReleaseResource resource)
+        {
+            // Check if the user data works with this model
+            if (!ModelState.IsValid)
+            {
+                return BadRequest(ModelState.GetErrorMessages());
+            }
+            
+            var result = await _releaseService.SaveAsync(resource);
+
+            if (!result.Success) return BadRequest(result.Message);
+
+            var releaseResource = _mapper.Map<Release, ReleaseResource>(result.Release);
+            return Ok(releaseResource);
+        }
+    }
+}

--- a/Domain/Models/Release.cs
+++ b/Domain/Models/Release.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 
@@ -13,8 +15,10 @@ namespace ReleaseNotes_WebAPI.Domain.Models
         
         public ProductVersion ProductVersion { get; set; }
         
-        public Article Article { get; set; }
+        public string Title { get; set; }
         
         public bool IsPublic { get; set; }
+        
+        public ICollection<ReleaseNote> ReleaseNotes { get; set; } = new Collection<ReleaseNote>();
     }
 }

--- a/Domain/Models/ReleaseNotes.cs
+++ b/Domain/Models/ReleaseNotes.cs
@@ -1,0 +1,11 @@
+namespace ReleaseNotes_WebAPI.Domain.Models
+{
+    public class ReleaseNotes
+    {
+        public int ReleaseId { get; set; }
+        public Release Release { get; set; }
+
+        public int ReleaseNoteId { get; set; }
+        public ReleaseNote ReleaseNote { get; set; }
+    }
+}

--- a/Domain/Repositories/IReleaseRepository.cs
+++ b/Domain/Repositories/IReleaseRepository.cs
@@ -1,0 +1,17 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using ReleaseNotes_WebAPI.Domain.Models;
+
+namespace ReleaseNotes_WebAPI.Domain.Repositories
+{
+    public interface IReleaseRepository
+    {
+        Task AddAsync(Release release);
+
+        Task<Release> FindByNameAsync(string release);
+
+        Task<ProductVersion> FindProductVersion(int id);
+
+        Task<ICollection<ReleaseNote>> FindReleaseNotes(IEnumerable<int> ids);
+    }
+}

--- a/Domain/Services/Communication/ReleaseResponse.cs
+++ b/Domain/Services/Communication/ReleaseResponse.cs
@@ -1,0 +1,33 @@
+using ReleaseNotes_WebAPI.Domain.Models;
+
+namespace ReleaseNotes_WebAPI.Domain.Services.Communication
+{
+    public class ReleaseResponse : BaseResponse
+    {
+
+        public Release Release { get; private set; }
+        
+        public ReleaseResponse(bool success, string message, Release release) : base(success, message)
+        {
+            Release = release;
+        }
+        
+        /// <summary>
+        /// Creates a success response.
+        /// </summary>
+        /// <param name="release">Saved release.</param>
+        /// <returns>Response.</returns>
+        public ReleaseResponse(Release release) : this(true, string.Empty, release)
+        {
+        }
+
+        /// <summary>
+        /// Creates am error response.
+        /// </summary>
+        /// <param name="message">Error message.</param>
+        /// <returns>Response.</returns>
+        public ReleaseResponse(string message) : this(false, message, null)
+        {
+        }
+    }
+}

--- a/Domain/Services/IReleaseService.cs
+++ b/Domain/Services/IReleaseService.cs
@@ -1,0 +1,12 @@
+using System.Threading.Tasks;
+using ReleaseNotes_WebAPI.Domain.Models;
+using ReleaseNotes_WebAPI.Domain.Services.Communication;
+using ReleaseNotes_WebAPI.Resources;
+
+namespace ReleaseNotes_WebAPI.Domain.Services
+{
+    public interface IReleaseService
+    {
+        Task<ReleaseResponse> SaveAsync(SaveReleaseResource release);
+    }
+}

--- a/Persistence/Repositories/ReleaseRepository.cs
+++ b/Persistence/Repositories/ReleaseRepository.cs
@@ -1,0 +1,37 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using ReleaseNotes_WebAPI.Domain.Models;
+using ReleaseNotes_WebAPI.Domain.Repositories;
+using ReleaseNotes_WebAPI.Persistence.Contexts;
+
+namespace ReleaseNotes_WebAPI.Persistence.Repositories
+{
+    public class ReleaseRepository : BaseRepository, IReleaseRepository
+    {
+        public ReleaseRepository(AppDbContext context) : base(context)
+        {
+        }
+
+        public async Task AddAsync(Release release)
+        {
+            await _context.Releases.AddAsync(release);
+        }
+        
+        public async Task<Release> FindByNameAsync(string releaseName)
+        {
+            return await _context.Releases.Where(r => r.Title == releaseName).SingleOrDefaultAsync();
+        }
+
+        public async Task<ProductVersion> FindProductVersion(int id)
+        {
+            return await _context.ProductVersions.FindAsync(id);
+        }
+
+        public async Task<ICollection<ReleaseNote>> FindReleaseNotes(IEnumerable<int> ids)
+        {
+            return await _context.ReleaseNotes.Where(rn => ids.Contains(rn.Id)).ToListAsync();
+        }
+    }
+}

--- a/ReleaseNotes-WebAPI.csproj
+++ b/ReleaseNotes-WebAPI.csproj
@@ -8,6 +8,7 @@
         <PackageReference Include="AutoMapper" Version="9.0.0" />
         <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="7.0.0" />
         <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="3.1.0" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.2" />
         <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.0" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="3.1.0" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="3.1.0" />

--- a/Resources/ReleaseResource.cs
+++ b/Resources/ReleaseResource.cs
@@ -1,9 +1,19 @@
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using ReleaseNotes_WebAPI.Domain.Models;
+
 namespace ReleaseNotes_WebAPI.Resources
 {
     public class ReleaseResource
     {
         public int Id { get; set; }
         
-        public ProductVersionResource ProductVersion { get; set; }
+        public ProductVersion ProductVersion { get; set; }
+        
+        public string Title { get; set; }
+        
+        public bool IsPublic { get; set; }
+        
+        public ICollection<ReleaseNote> ReleaseNotes { get; set; } = new Collection<ReleaseNote>();
     }
 }

--- a/Resources/SaveReleaseResource.cs
+++ b/Resources/SaveReleaseResource.cs
@@ -1,0 +1,16 @@
+using System.Collections.Generic;
+using ReleaseNotes_WebAPI.Domain.Models;
+
+namespace ReleaseNotes_WebAPI.Resources
+{
+    public class SaveReleaseResource
+    {
+        public int ProductVersionId { get; set; }
+        
+        public string Title { get; set; }
+        
+        public bool IsPublic { get; set; }
+        
+        public IEnumerable<int> ReleaseNotesId { get; set; }
+    }
+}

--- a/Services/ReleaseService.cs
+++ b/Services/ReleaseService.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Threading.Tasks;
+using ReleaseNotes_WebAPI.Domain.Models;
+using ReleaseNotes_WebAPI.Domain.Repositories;
+using ReleaseNotes_WebAPI.Domain.Services;
+using ReleaseNotes_WebAPI.Domain.Services.Communication;
+using ReleaseNotes_WebAPI.Resources;
+
+namespace ReleaseNotesWebAPI.Services
+{
+    public class ReleaseService : IReleaseService
+    {
+        private readonly IReleaseRepository _releaseRepository;
+        private readonly IUnitOfWork _unitOfWork;
+
+        public ReleaseService(IReleaseRepository releaseRepository, IUnitOfWork unitOfWork)
+        {
+            _releaseRepository = releaseRepository;
+            _unitOfWork = unitOfWork;
+        }
+
+        public async Task<ReleaseResponse> SaveAsync(SaveReleaseResource resource)
+        {
+            try
+            {
+                var existingRelease = await _releaseRepository.FindByNameAsync(resource.Title);
+
+                if (existingRelease != null)
+                {
+                    return new ReleaseResponse("Release med navnet: " + resource.Title + " finnes allerede i databasen.");
+                }
+
+                Release release;
+                try
+                {
+                    release = new Release
+                    {
+                        Title = resource.Title,
+                        IsPublic = resource.IsPublic,
+                        ProductVersion = await _releaseRepository.FindProductVersion(resource.ProductVersionId),
+                        ReleaseNotes = await _releaseRepository.FindReleaseNotes(resource.ReleaseNotesId)
+                    };
+                }
+                catch (Exception e)
+                {
+                    return new ReleaseResponse(e.Message);
+                }
+
+
+                await _releaseRepository.AddAsync(release);
+                await _unitOfWork.CompleteAsync();
+
+                return new ReleaseResponse(release);
+            }
+            catch (Exception e)
+            {
+                return new ReleaseResponse(
+                    $"En feil oppsto når førsøkte å opprette nytt produkt: {e.Message}");
+            }
+        }
+    }
+}

--- a/Startup.cs
+++ b/Startup.cs
@@ -10,6 +10,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.IdentityModel.Logging;
 using Microsoft.IdentityModel.Tokens;
+using Newtonsoft.Json;
 using ReleaseNotes_WebAPI.API.Services;
 using ReleaseNotes_WebAPI.Domain.Models.Auth.Token;
 using ReleaseNotes_WebAPI.Domain.Repositories;
@@ -19,6 +20,7 @@ using ReleaseNotes_WebAPI.Persistence.Contexts;
 using ReleaseNotes_WebAPI.Persistence.Repositories;
 using ReleaseNotes_WebAPI.Security.Tokens;
 using ReleaseNotes_WebAPI.Services;
+using ReleaseNotesWebAPI.Services;
 using TokenHandler = ReleaseNotes_WebAPI.Security.Tokens.TokenHandler;
 
 namespace ReleaseNotes_WebAPI
@@ -59,6 +61,7 @@ namespace ReleaseNotes_WebAPI
             services.AddScoped<IUserRepository, UserRepository>();
             services.AddScoped<IArticleRepository, ArticleRepository>();
             services.AddScoped<IProductRepository, ProductRepository>();
+            services.AddScoped<IReleaseRepository, ReleaseRepository>();
 
             // BIND ALL SERVICES
             services.AddScoped<IUnitOfWork, UnitOfWork>();
@@ -66,6 +69,7 @@ namespace ReleaseNotes_WebAPI
             services.AddScoped<IArticleService, ArticleService>();
             services.AddScoped<IUserService, UserService>();
             services.AddScoped<IProductService, ProductService>();
+            services.AddScoped<IReleaseService, ReleaseService>();
             
             // CONFIGURE AUTHENTICATION AND TOKEN OPTIONS
             services.Configure<TokenOptions>(Configuration.GetSection("TokenOptions"));
@@ -128,7 +132,8 @@ namespace ReleaseNotes_WebAPI
             services.AddAutoMapper(typeof(Startup));
 
             // ADD ALL CONTROLLERS (ENDPOINTS)
-            services.AddControllers();
+            services.AddControllers().AddNewtonsoftJson(
+                options => options.SerializerSettings.ReferenceLoopHandling = ReferenceLoopHandling.Ignore);
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.


### PR DESCRIPTION
- Added new dependency for handling json parsing, where the one we previously used couldn't handle reference loophandling.
https://stackoverflow.com/questions/57912012/net-core-3-upgrade-cors-and-jsoncycle-xmlhttprequest-error

- Added new model ReleaseNotes. This will be used to contain the many-to-many relation between Release and Release Note.
- Added new authorized endpoint for creating a new release.
- Created all the services required for creating the new release.