### PR TITLE
Bugfix wrong auth get release

### DIFF
--- a/Controllers/ReleasesController.cs
+++ b/Controllers/ReleasesController.cs
@@ -59,7 +59,6 @@ namespace ReleaseNotes_WebAPI.Controllers
         }
 
         [HttpGet("{id}")]
-        [Authorize(Roles = "Administrator")]
         public async Task<ActionResult<ReleaseResource>> GetAsync(int id)
         {
             var releaseResponse = await _releaseService.GetRelease(id);

--- a/TestContainer/test/testReleases.js
+++ b/TestContainer/test/testReleases.js
@@ -188,17 +188,6 @@ describe("Releases GET", () => {
       });
   });
 
-  // failure case for getting a single release due to not logging in, 401 unauth
-  it("GET | Should return a 401 unauth", done => {
-    chai
-      .request(process.env.APP_URL)
-      .get(addressGet)
-      .end(err => {
-        err.should.have.status(401);
-        done();
-      });
-  });
-
   // failure case: Logged in and attempting to get a release that does not exist
   it("GET | Should return a 204 no content", done => {
     chai
@@ -211,17 +200,6 @@ describe("Releases GET", () => {
           done(err.response.text);
         }
         res.should.have.status(204);
-        done();
-      });
-  });
-
-  // failure case: not logged in and attempting to get a release that does not exist
-  it("GET | Should return a 401 unauth", done => {
-    chai
-      .request(process.env.APP_URL)
-      .get(addressGetFail)
-      .end(err => {
-        expect(err.should.have.status(401));
         done();
       });
   });


### PR DESCRIPTION
- Removed tests that collide.
-  Removed authorization for getting a single release, this is something that should be available for everyone, not just admins..

