### PR TITLE
Fix update releaseNote making fields NULL

### DIFF
--- a/Controllers/ReleaseNoteController.cs
+++ b/Controllers/ReleaseNoteController.cs
@@ -86,7 +86,7 @@ namespace ReleaseNotes_WebAPI.Controllers
         [HttpPost()]
         [Authorize(Roles = ("Administrator"))]
         public async Task<ActionResult<ReleaseNoteResource>> CreateReleaseNoteAsync(
-            [FromBody] EditReleaseNoteResource resource)
+            [FromBody] CreateReleaseNoteResource resource)
         {
             if (!ModelState.IsValid)
             {

--- a/Domain/Services/IReleaseNoteService.cs
+++ b/Domain/Services/IReleaseNoteService.cs
@@ -20,6 +20,6 @@ namespace ReleaseNotes_WebAPI.Domain.Services
 
         Task<ReleaseNoteResponse> UpdateReleaseNote(int id, EditReleaseNoteResource note);
 
-        Task<ReleaseNoteResponse> CreateReleaseNote(EditReleaseNoteResource note);
+        Task<ReleaseNoteResponse> CreateReleaseNote(CreateReleaseNoteResource note);
     }
 }

--- a/Mapping/ResourceToModelProfile.cs
+++ b/Mapping/ResourceToModelProfile.cs
@@ -15,7 +15,9 @@ namespace ReleaseNotes_WebAPI.Mapping
             CreateMap<UserCredentialResource, User>();
             CreateMap<UpdateUserPasswordResource, User>();
             CreateMap<ReleaseNoteResource, ReleaseNote>();
-            CreateMap<EditReleaseNoteResource, ReleaseNote>();
+            CreateMap<EditReleaseNoteResource, ReleaseNote>().ForAllMembers(
+                opt => opt.Condition((src, dest, sourceMember) => sourceMember != null));
+            CreateMap<CreateReleaseNoteResource, ReleaseNote>();
             CreateMap<SaveReleaseResource, Release>();
             CreateMap<SaveProductResource, Product>();
         }

--- a/Resources/CreateReleaseNoteResource.cs
+++ b/Resources/CreateReleaseNoteResource.cs
@@ -2,10 +2,11 @@
 
 namespace ReleaseNotes_WebAPI.Resources
 {
-    public class EditReleaseNoteResource
-    {    
+    public class CreateReleaseNoteResource
+    {
         public string Title { get; set; }
         public string Ingress { get; set; }
+        [Required]
         public string Description { get; set; }
         public bool IsPublic { get; set; }
     }

--- a/Services/ReleaseNoteService.cs
+++ b/Services/ReleaseNoteService.cs
@@ -83,10 +83,7 @@ namespace ReleaseNotes_WebAPI.Services
 
             try
             {
-                existingReleaseNote.Title = note.Title;
-                existingReleaseNote.Ingress = note.Ingress;
-                existingReleaseNote.Description = note.Description;
-                existingReleaseNote.IsPublic = note.IsPublic;
+                _mapper.Map(note, existingReleaseNote);
                 _releaseNoteRepository.UpdateReleaseNote(existingReleaseNote);
                 await _unitOfWork.CompleteAsync();
                 return new ReleaseNoteResponse(existingReleaseNote);
@@ -97,7 +94,7 @@ namespace ReleaseNotes_WebAPI.Services
             }
         }
 
-        public async Task<ReleaseNoteResponse> CreateReleaseNote(EditReleaseNoteResource note)
+        public async Task<ReleaseNoteResponse> CreateReleaseNote(CreateReleaseNoteResource note)
         {
             try
             {


### PR DESCRIPTION
Update releasenotes gjorde felt til NULL når dei ikkje va inkludert i request bodyen. Fiksa det med bruke automapper til å oppdatere entiteten, og laga en automapper konfigurasjon som ignorera null-verdia. Også seperert resourcen til CREATE og UPDATE releaseNote, fordi CREATE krevde `required` på description, mens det ikkje gir meining i UPDATE