### PR TITLE
AB#247 Allow Release Notes to created in POST Release

### DIFF
--- a/Resources/SaveReleaseResource.cs
+++ b/Resources/SaveReleaseResource.cs
@@ -1,10 +1,12 @@
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
 using ReleaseNotes_WebAPI.Domain.Models;
 
 namespace ReleaseNotes_WebAPI.Resources
 {
     public class SaveReleaseResource
     {
+        [Required]
         public int ProductVersionId { get; set; }
         
         public string Title { get; set; }
@@ -12,5 +14,7 @@ namespace ReleaseNotes_WebAPI.Resources
         public bool IsPublic { get; set; }
         
         public IEnumerable<int> ReleaseNotesId { get; set; }
+        
+        public IEnumerable<ReleaseNote> ReleaseNotes { get; set; }
     }
 }

--- a/Services/ReleaseService.cs
+++ b/Services/ReleaseService.cs
@@ -138,7 +138,17 @@ namespace ReleaseNotesWebAPI.Services
                     var releaseReleaseNotes = new List<ReleaseReleaseNote>();
                     
                     // Retrieve all ReleaseNotes from database
-                    var releaseNotes = await _releaseRepository.FindReleaseNotes(resource.ReleaseNotesId);
+                    IEnumerable<ReleaseNote> releaseNotes;
+
+                    if (resource.ReleaseNotesId != null && resource.ReleaseNotes != null)
+                    {
+                        releaseNotes = await _releaseRepository.FindReleaseNotes(resource.ReleaseNotesId);
+                    }
+                    else
+                    {
+                        // Create new Release Notes
+                        releaseNotes = resource.ReleaseNotes;
+                    }
                     
                     // Map each ReleaseNote to this Release
                     foreach (var releaseNote in releaseNotes)

--- a/TestContainer/test/testReleases.js
+++ b/TestContainer/test/testReleases.js
@@ -20,6 +20,23 @@ const TEST_RELEASE_2 = {
   ReleaseNotesId: [1]
 };
 
+const TEST_RELEASE_NEW_RELEASE_NOTE = {
+  isPublic: false,
+  title: "Release-7",
+  ProductVersionId: 100,
+  releaseNotes: [
+    {
+      AuthorEmail: "markuran@ntnu.no",
+      AuthorName: "Markus Randa",
+      ClosedDate: "2020-03-26T18:38:58.993Z",
+      WorkItemDescriptionHtml:
+        '<div>Wireframe:</div><div><a href="https://confluence.uials.no/pages/viewpage.action?pageId=57378685">https://confluence.uials.no/pages/viewpage.action?pageId=57378685</a></div><div><br></div><div>ERD:</div><div><a href="https://confluence.uials.no/pages/viewpage.action?pageId=57377417">https://confluence.uials.no/pages/viewpage.action?pageId=57377417</a><br></div>',
+      WorkitemId: 235,
+      WorkItemTitle: "Front-end: Oppdater state med azure-projects"
+    }
+  ]
+};
+
 const TEST_RELEASE_3 = {
   IsPublic: false
 };
@@ -77,6 +94,26 @@ describe("Releases POST", () => {
           done(err.response.text);
         }
         res.should.have.status(200);
+        done();
+      });
+  });
+
+  // should return 200 OK
+  it("CREATE | Successfully creating a release with non existing Release Note", done => {
+    chai
+      .request(process.env.APP_URL)
+      .post(addressReleases)
+      .set("Content-Type", "application/json")
+      .set("Authorization", "Bearer " + accessToken)
+      .send(TEST_RELEASE_NEW_RELEASE_NOTE)
+      .end((err, res) => {
+        if (err) {
+          done(err.response.text);
+        }
+        res.should.have.status(200);
+        res.body.releaseNotes.should.be.a("array");
+        res.body.releaseNotes.should.not.be.empty;
+        res.body.releaseNotes.should;
         done();
       });
   });


### PR DESCRIPTION
Post Releases will now automatically create any ReleaseNotes specified in the body of the request.