### PR TITLE
Get release notes can include associated Releases AB#268

### DIFF
--- a/Controllers/ReleaseNoteController.cs
+++ b/Controllers/ReleaseNoteController.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿ using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using AutoMapper;
 using Microsoft.AspNetCore.Authorization;
@@ -50,9 +51,11 @@ namespace ReleaseNotes_WebAPI.Controllers
 
         // GET: api/releasenote/{id}
         [HttpGet("{id}")]
-        public async Task<ActionResult<ReleaseNoteResource>> GetSpecificReleaseNote(int id)
+        public async Task<ActionResult<ReleaseNoteResource>> GetSpecificReleaseNote(
+            [FromQuery] bool includeReleases, 
+            int id)
         {
-            var releaseNoteResponse = await _releaseNoteService.GetReleaseNote(id);
+            var releaseNoteResponse = await _releaseNoteService.GetReleaseNote(id, includeReleases);
             if (releaseNoteResponse == null)
             {
                 return NotFound();

--- a/Domain/ModelBinder/IBooleanModelBinder.cs
+++ b/Domain/ModelBinder/IBooleanModelBinder.cs
@@ -1,0 +1,10 @@
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+
+namespace ReleaseNotes_WebAPI.Domain.ModelBinder
+{
+    public interface IBooleanModelBinder
+    {
+        public Task BindModelAsync(ModelBindingContext bindingContext);
+    }
+}

--- a/Domain/Repositories/lReleaseNoteRepository.cs
+++ b/Domain/Repositories/lReleaseNoteRepository.cs
@@ -13,6 +13,7 @@ namespace ReleaseNotes_WebAPI.Domain.Repositories
         
         void AddAsync(ReleaseNote releaseNote);
 
+        Task<ReleaseNote> FindAsync(int id, bool includeReleases);
         Task<ReleaseNote> FindAsync(int id);
 
         void UpdateReleaseNote(ReleaseNote note);

--- a/Domain/Services/IReleaseNoteService.cs
+++ b/Domain/Services/IReleaseNoteService.cs
@@ -14,7 +14,7 @@ namespace ReleaseNotes_WebAPI.Domain.Services
 
         Task<IEnumerable<ReleaseNote>> FilterDates(ReleaseNoteParameters queryParameters);
 
-        Task<ReleaseNoteResponse> GetReleaseNote(int id);
+        Task<ReleaseNoteResponse> GetReleaseNote(int id, bool includeReleases);
 
         Task<ReleaseNoteResponse> RemoveReleaseNote(int id);
 

--- a/Mapping/ModelToResourceProfile.cs
+++ b/Mapping/ModelToResourceProfile.cs
@@ -49,8 +49,13 @@ namespace ReleaseNotes_WebAPI.Mapping
                 .ForMember(dest => dest.Versions, 
                     opt => 
                         opt.MapFrom(src => src.ProductVersions));
-            
-            CreateMap<ReleaseNote, ReleaseNoteResource>();
+
+            CreateMap<ReleaseNote, ReleaseNoteResource>()
+                .ForMember(dest => dest.Releases,
+                    opt =>
+                        opt.MapFrom(src =>
+                            src.ReleaseReleaseNotes.Select(rrn => rrn.Release).Select(r => 
+                                new Release() {Date = r.Date, Id = r.Id,Title = r.Title,IsPublic = r.IsPublic,ProductVersion = r.ProductVersion})));
         }
     }
 }

--- a/ModelBinder/BooleanModelBinder.cs
+++ b/ModelBinder/BooleanModelBinder.cs
@@ -1,0 +1,46 @@
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+
+namespace ReleaseNotes_WebAPI.ModelBinder
+{
+    class BooleanModelBinder : IModelBinder
+    {
+        /**
+         * Makes sure that every boolean query parameter gets interpreted as false if they're not
+         * included, and true if they truly are included. 
+         */
+        public Task BindModelAsync(ModelBindingContext bindingContext)
+        {
+            var result = bindingContext.ValueProvider.GetValue(bindingContext.ModelName);
+            if (result == ValueProviderResult.None)
+            {
+                // Parameter is missing, interpret as false
+                bindingContext.Result = ModelBindingResult.Success(false);
+            }
+            else
+            {
+                bindingContext.ModelState.SetModelValue(bindingContext.ModelName, result);
+                var rawValue = result.FirstValue;
+                if (string.IsNullOrEmpty(rawValue))
+                {
+                    // Value is empty, interpret as true
+                    bindingContext.Result = ModelBindingResult.Success(true);
+                }
+                else if (bool.TryParse(rawValue, out var boolValue))
+                {
+                    // Value is a valid boolean, use that value
+                    bindingContext.Result = ModelBindingResult.Success(boolValue);
+                }
+                else
+                {
+                    // Value is something else, fail
+                    bindingContext.ModelState.TryAddModelError(
+                        bindingContext.ModelName,
+                        "Value must be false, true, or empty.");
+                }
+            }
+ 
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/ModelBinder/BooleanModelProvider.cs
+++ b/ModelBinder/BooleanModelProvider.cs
@@ -1,0 +1,16 @@
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+
+namespace ReleaseNotes_WebAPI.ModelBinder
+{
+    class BooleanModelBinderProvider : IModelBinderProvider
+    {
+        public IModelBinder GetBinder(ModelBinderProviderContext context)
+        {
+            if (context.Metadata.ModelType == typeof(bool))
+            {
+                return new BooleanModelBinder();
+            }
+ 
+            return null;
+        }
+    }}

--- a/Persistence/Repositories/ReleaseNoteRepository.cs
+++ b/Persistence/Repositories/ReleaseNoteRepository.cs
@@ -43,15 +43,10 @@ namespace ReleaseNotes_WebAPI.Persistence.Repositories
 
         public async Task<ReleaseNote> FindAsync(int id, bool includeReleases)
         {
-            if (includeReleases)
-            {
-                return await _context.ReleaseNotes
-                    .Where(note => note.Id == id)
-                    .Include(rn => rn.ReleaseReleaseNotes)
-                    .ThenInclude(rrn => rrn.Release)
-                    .SingleAsync();
-            }
-            return await _context.ReleaseNotes.FindAsync(id);
+            return await _context.ReleaseNotes
+                .Include(rn => rn.ReleaseReleaseNotes)
+                .ThenInclude(rrn => rrn.Release)
+                .SingleOrDefaultAsync(note => note.Id == id);
         }
 
         public void UpdateReleaseNote(ReleaseNote note)

--- a/Persistence/Repositories/ReleaseNoteRepository.cs
+++ b/Persistence/Repositories/ReleaseNoteRepository.cs
@@ -41,6 +41,19 @@ namespace ReleaseNotes_WebAPI.Persistence.Repositories
             return await _context.ReleaseNotes.FindAsync(id);
         }
 
+        public async Task<ReleaseNote> FindAsync(int id, bool includeReleases)
+        {
+            if (includeReleases)
+            {
+                return await _context.ReleaseNotes
+                    .Where(note => note.Id == id)
+                    .Include(rn => rn.ReleaseReleaseNotes)
+                    .ThenInclude(rrn => rrn.Release)
+                    .SingleAsync();
+            }
+            return await _context.ReleaseNotes.FindAsync(id);
+        }
+
         public void UpdateReleaseNote(ReleaseNote note)
         {
             _context.ReleaseNotes.Update(note);

--- a/Resources/ReleaseNoteResource.cs
+++ b/Resources/ReleaseNoteResource.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using ReleaseNotes_WebAPI.Domain.Models;
 
 namespace ReleaseNotes_WebAPI.Resources
@@ -16,5 +17,6 @@ namespace ReleaseNotes_WebAPI.Resources
         public int WorkItemId { get; set; }
         public DateTime ClosedDate { get; set; }
         public bool IsPublic { get; set; }
+        public ICollection<Release> Releases { get; set; }
     }
 }

--- a/Services/ReleaseNoteService.cs
+++ b/Services/ReleaseNoteService.cs
@@ -34,9 +34,9 @@ namespace ReleaseNotes_WebAPI.Services
             return await _releaseNoteRepository.FilterDates(queryParameters);
         }
 
-        public async Task<ReleaseNoteResponse> GetReleaseNote(int id)
+        public async Task<ReleaseNoteResponse> GetReleaseNote(int id, bool includeReleases)
         {
-            var existingReleaseNote = await _releaseNoteRepository.FindAsync(id);
+            var existingReleaseNote = await _releaseNoteRepository.FindAsync(id, includeReleases);
             if (existingReleaseNote == null)
             {
                 return new ReleaseNoteResponse("Release noten eksisterer ikke!");

--- a/Services/ReleaseNoteService.cs
+++ b/Services/ReleaseNoteService.cs
@@ -36,7 +36,16 @@ namespace ReleaseNotes_WebAPI.Services
 
         public async Task<ReleaseNoteResponse> GetReleaseNote(int id, bool includeReleases)
         {
-            var existingReleaseNote = await _releaseNoteRepository.FindAsync(id, includeReleases);
+            ReleaseNote existingReleaseNote;
+            if (includeReleases)
+            {
+                existingReleaseNote = await _releaseNoteRepository.FindAsync(id, true);
+            }
+            else
+            {
+                existingReleaseNote = await _releaseNoteRepository.FindAsync(id);
+
+            }
             if (existingReleaseNote == null)
             {
                 return new ReleaseNoteResponse("Release noten eksisterer ikke!");

--- a/Startup.cs
+++ b/Startup.cs
@@ -16,6 +16,7 @@ using ReleaseNotes_WebAPI.Domain.Models.Auth.Token;
 using ReleaseNotes_WebAPI.Domain.Repositories;
 using ReleaseNotes_WebAPI.Domain.Security;
 using ReleaseNotes_WebAPI.Domain.Services;
+using ReleaseNotes_WebAPI.ModelBinder;
 using ReleaseNotes_WebAPI.Persistence.Contexts;
 using ReleaseNotes_WebAPI.Persistence.Repositories;
 using ReleaseNotes_WebAPI.Security.Tokens;
@@ -144,8 +145,16 @@ namespace ReleaseNotes_WebAPI
             services.AddAutoMapper(typeof(Startup));
 
             // ADD ALL CONTROLLERS (ENDPOINTS)
-            services.AddControllers().AddNewtonsoftJson(
-                options => options.SerializerSettings.ReferenceLoopHandling = ReferenceLoopHandling.Ignore);
+            services.AddControllers(
+                options =>
+                {
+                    options.ModelBinderProviders.Insert(0, new BooleanModelBinderProvider());
+                }
+                ).AddNewtonsoftJson(
+                options =>
+                {
+                    options.SerializerSettings.ReferenceLoopHandling = ReferenceLoopHandling.Ignore;
+                });
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/TestContainer/test/testReleaseNotes.js
+++ b/TestContainer/test/testReleaseNotes.js
@@ -20,7 +20,7 @@ const RELEASE_NOTE_WITHOUT_DESCRIPTION = {
   ingress:
     "Det er en tirsdag i 2020. Det neste du leser vil absolutt blåse minnet ditt.",
   isPublic: "false",
-  authorName: "postman@ungspiller.no"
+  authorName: "postman@ungspiller.no",
 };
 
 const CORRECT_DATE_FILTER =
@@ -38,7 +38,7 @@ describe("Release notes GET", () => {
   before(() => init());
 
   // should return 200 OK and a array of release notes
-  it("GET | Get all release notes", done => {
+  it("GET | Get all release notes", (done) => {
     chai
       .request(process.env.APP_URL)
       .get(addressGet)
@@ -60,30 +60,8 @@ describe("Release notes GET", () => {
       });
   });
 
-  // should return a 200 OK and specified release note
-  it("GET | Get a single release", done => {
-    chai
-      .request(process.env.APP_URL)
-      .get(addressGetSingle)
-      .end((err, res) => {
-        if (err) {
-          done(err.response.text);
-        }
-        expect(res.body.title).to.be.a("string").that.is.not.empty;
-        expect(res.body.ingress).to.be.a("string").that.is.not.empty;
-        expect(res.body.description).to.be.a("string").that.is.not.empty;
-        expect(res.body.authorName).to.be.a("string").that.is.not.empty;
-        expect(res.body.authorEmail).to.be.a("string").that.is.not.empty;
-        expect(res.body.workItemTitle).to.be.a("string").that.is.not.empty;
-        expect(res.body.isPublic).to.equal(false);
-        expect(res.body.workItemId).to.be.a("number");
-        res.should.have.status(200);
-        done();
-      });
-  });
-
   // should return 200 OK and  a singe release note
-  it("GET | Successfully gets a single release note", done => {
+  it("GET | Successfully gets a single release note", (done) => {
     chai
       .request(process.env.APP_URL)
       .get(addressGetSingle)
@@ -104,8 +82,31 @@ describe("Release notes GET", () => {
       });
   });
 
+  // should return 200 OK and  a singe release note
+  it("GET | Successfully gets a single release note with associated releases", (done) => {
+    chai
+      .request(process.env.APP_URL)
+      .get(addressGetSingle)
+      .query("includeReleases")
+      .end((err, res) => {
+        if (err) {
+          done(err.response);
+        }
+        res.should.have.status(200);
+        expect(res.body.id).to.be.a("number");
+        expect(res.body.title).to.be.a("string").that.is.not.empty;
+        expect(res.body.ingress).to.be.a("string").that.is.not.empty;
+        expect(res.body.authorName).to.be.a("string").that.is.not.empty;
+        expect(res.body.authorEmail).to.be.a("string").that.is.not.empty;
+        expect(res.body.isPublic).to.be.a("boolean");
+        expect(res.body.workItemId).to.be.a("number");
+        expect(res.body.releases).to.be.a("array").that.is.not.empty;
+        done();
+      });
+  });
+
   // should return a 204 No Content
-  it("GET | requests a non-existant release note", done => {
+  it("GET | requests a non-existant release note", (done) => {
     chai
       .request(process.env.APP_URL)
       .get(addressGetSingleFail)
@@ -118,7 +119,7 @@ describe("Release notes GET", () => {
       });
   });
 
-  it("GET | Get Release Notes from a set date interval", done => {
+  it("GET | Get Release Notes from a set date interval", (done) => {
     chai
       .request(process.env.APP_URL)
       .get(addressGet + CORRECT_DATE_FILTER)
@@ -127,9 +128,9 @@ describe("Release notes GET", () => {
           done(err.response.text);
         }
         // Checking if each object's date corresponds to filter
-        res.body.map(obj => {
+        res.body.map((obj) => {
           const date = new Date(obj.closedDate);
-          expect(date.getTime()).to.satisfy(num => {
+          expect(date.getTime()).to.satisfy((num) => {
             return num >= startDate.getTime() && num <= endDate.getTime();
           });
         });
@@ -146,14 +147,14 @@ describe("Release note PUT", () => {
 describe("Release note POST", () => {
   before(() => init());
 
-  it("POST | Tries to create release note without providing a description", done => {
+  it("POST | Tries to create release note without providing a description", (done) => {
     chai
       .request(process.env.APP_URL)
       .post(addressReleaseNote)
       .set("Content-Type", "application/json")
       .set("Authorization", "Bearer " + accessToken)
       .send(RELEASE_NOTE_WITHOUT_DESCRIPTION)
-      .end(err => {
+      .end((err) => {
         expect(err.should.have.status(400));
         done();
       });
@@ -165,11 +166,11 @@ describe("Release notes DELETE", () => {
 
   // failure case: Tries to delete a release note without being logged in
   // should return a 401 unauth
-  it("DELETE | Tries to delete a release note without being logged in", done => {
+  it("DELETE | Tries to delete a release note without being logged in", (done) => {
     chai
       .request(process.env.APP_URL)
       .delete(addressDelete)
-      .end(err => {
+      .end((err) => {
         expect(err.should.have.status(401));
         done();
       });
@@ -177,13 +178,13 @@ describe("Release notes DELETE", () => {
 
   // failure case: Tries to delete a non-existant release note
   // should return a 400 Bad Request
-  it("DELETE | Tries to delete a non-existant release note", done => {
+  it("DELETE | Tries to delete a non-existant release note", (done) => {
     chai
       .request(process.env.APP_URL)
       .delete(addressDeleteFail)
       .set("Content-Type", "application/json")
       .set("Authorization", "Bearer " + accessToken)
-      .end(err => {
+      .end((err) => {
         expect(err.should.have.status(400));
         done();
       });
@@ -191,7 +192,7 @@ describe("Release notes DELETE", () => {
 
   // succes case: deletes a release note
   // should return a 200 OK and a copy of the newly deleted release note
-  it("DELETE | Should return a OK 200 and a copy of the deleted release note", done => {
+  it("DELETE | Should return a OK 200 and a copy of the deleted release note", (done) => {
     chai
       .request(process.env.APP_URL)
       .delete(addressDelete)
@@ -209,13 +210,13 @@ describe("Release notes DELETE", () => {
 
   // failure case: Tries to delete a already deleted release note
   // should return a 400 Bad Request
-  it("DELETE | Tries to delete a already deleted release note", done => {
+  it("DELETE | Tries to delete a already deleted release note", (done) => {
     chai
       .request(process.env.APP_URL)
       .delete(addressDelete)
       .set("Content-Type", "application/json")
       .set("Authorization", "Bearer " + accessToken)
-      .end(err => {
+      .end((err) => {
         expect(err.should.have.status(400));
         done();
       });


### PR DESCRIPTION
Det som er lagt ved i denne PR, er endringer som gjør det mulig å inkludere `includeReleases` som et parameter på requester til "Get Specific Release Note" på url `/api/releasenote/3?includeReleases`.

Det som da blir returnert er en liste med releases som er assosiert med nevnt Release Note.