### PR TITLE
server response tests #AB255

### DIFF
--- a/TestContainer/test/testUsers.js
+++ b/TestContainer/test/testUsers.js
@@ -2,6 +2,7 @@ var TokenHandler = require("../TokenHandler");
 const chai = require("chai");
 const chaiHttp = require("chai-http");
 const should = chai.should();
+const { expect } = require("chai");
 
 chai.use(chaiHttp);
 
@@ -24,6 +25,13 @@ const WRONG_INPUT_USER_ID = 420;
 const WRONG_INPUT_PASSWORD = {
   password: "1234"
 };
+
+// Response messages
+const PW_CHANGE_SUCCESS_RESPONSE = "Brukeren har nå fått et nytt passord!";
+const NONEXISTANT_USER = "Denne brukeren eksisterer ikke!"
+const SAME_PW_RESPONSE = "Passordet kan ikke være likt det gamle!";
+const TOO_FEW_CHARACTERS_RESPONSE = '{"Password":["The field Password must be a string or array type with a minimum length of \'5\'."]}';
+
 
 var accessToken;
 
@@ -89,6 +97,7 @@ describe("Change password", () => {
         if (err) {
           done(err.response.text);
         }
+        expect(res.text).to.equal(PW_CHANGE_SUCCESS_RESPONSE);
         res.should.have.status(200);
         done();
       });
@@ -117,6 +126,7 @@ describe("Change password", () => {
       .set("Authorization", "Bearer " + accessToken)
       .send(CORRECT_INPUT_NEW_PASSWORD)
       .end(err => {
+        expect(err.response.text).to.equal(NONEXISTANT_USER);
         err.should.have.status(400);
         done();
       });
@@ -130,6 +140,7 @@ describe("Change password", () => {
       .set("Authorization", "Bearer " + accessToken)
       .send(CORRECT_INPUT_NEW_PASSWORD)
       .end(err => {
+        expect(err.response.text).to.equal(SAME_PW_RESPONSE);
         err.should.have.status(400);
         done();
       });
@@ -143,6 +154,7 @@ describe("Change password", () => {
       .set("Authorization", "Bearer " + accessToken)
       .send(WRONG_INPUT_PASSWORD)
       .end(err => {
+        expect(err.response.text).to.equal(TOO_FEW_CHARACTERS_RESPONSE);
         err.should.have.status(400);
         done();
       });

--- a/TestContainer/test/testUsers.js
+++ b/TestContainer/test/testUsers.js
@@ -1,8 +1,6 @@
 var TokenHandler = require("../TokenHandler");
 const chai = require("chai");
 const chaiHttp = require("chai-http");
-const should = chai.should();
-const { expect } = require("chai");
 
 chai.use(chaiHttp);
 
@@ -25,13 +23,6 @@ const WRONG_INPUT_USER_ID = 420;
 const WRONG_INPUT_PASSWORD = {
   password: "1234"
 };
-
-// Response messages
-const PW_CHANGE_SUCCESS_RESPONSE = "Brukeren har nå fått et nytt passord!";
-const NONEXISTANT_USER = "Denne brukeren eksisterer ikke!"
-const SAME_PW_RESPONSE = "Passordet kan ikke være likt det gamle!";
-const TOO_FEW_CHARACTERS_RESPONSE = '{"Password":["The field Password must be a string or array type with a minimum length of \'5\'."]}';
-
 
 var accessToken;
 
@@ -97,7 +88,6 @@ describe("Change password", () => {
         if (err) {
           done(err.response.text);
         }
-        expect(res.text).to.equal(PW_CHANGE_SUCCESS_RESPONSE);
         res.should.have.status(200);
         done();
       });
@@ -126,7 +116,6 @@ describe("Change password", () => {
       .set("Authorization", "Bearer " + accessToken)
       .send(CORRECT_INPUT_NEW_PASSWORD)
       .end(err => {
-        expect(err.response.text).to.equal(NONEXISTANT_USER);
         err.should.have.status(400);
         done();
       });
@@ -140,7 +129,6 @@ describe("Change password", () => {
       .set("Authorization", "Bearer " + accessToken)
       .send(CORRECT_INPUT_NEW_PASSWORD)
       .end(err => {
-        expect(err.response.text).to.equal(SAME_PW_RESPONSE);
         err.should.have.status(400);
         done();
       });
@@ -154,7 +142,6 @@ describe("Change password", () => {
       .set("Authorization", "Bearer " + accessToken)
       .send(WRONG_INPUT_PASSWORD)
       .end(err => {
-        expect(err.response.text).to.equal(TOO_FEW_CHARACTERS_RESPONSE);
         err.should.have.status(400);
         done();
       });


### PR DESCRIPTION
Tester om serverer gir responser som hjelper brukeren å få et gyldig passord. 

Responsen om passordet er for kort er litt rar grunnet måten kravet er satt i `UpdateUserPasswordResource`, men brukeren bør ikke kunne sende et slikt passord grunnet lokale sjekker i browser ved endring av passord