### PR TITLE
Data Authorization AB#274

### DIFF
--- a/Persistence/Contexts/AppDbContext.cs
+++ b/Persistence/Contexts/AppDbContext.cs
@@ -57,14 +57,11 @@ namespace ReleaseNotes_WebAPI.Persistence.Contexts
             
             // All entities that require extra security for isPublic
             builder.Entity<Release>().HasQueryFilter(
-                r => r.IsPublic && !UserIsAdmin || !r.IsPublic && UserIsAdmin ||
-                     r.IsPublic && UserIsAdmin);
+                r => !(!r.IsPublic && !UserIsAdmin));
             builder.Entity<ProductVersion>().HasQueryFilter(
-                pr => pr.IsPublic && !UserIsAdmin || !pr.IsPublic && UserIsAdmin ||
-                     pr.IsPublic && UserIsAdmin);
+                pr => !(!pr.IsPublic && !UserIsAdmin));
             builder.Entity<ReleaseNote>().HasQueryFilter(
-                rn => rn.IsPublic && !UserIsAdmin || !rn.IsPublic && UserIsAdmin ||
-                     rn.IsPublic && UserIsAdmin);
+                rn => !(!rn.IsPublic && !UserIsAdmin));
         }
     }
 }

--- a/Persistence/Contexts/AppDbContext.cs
+++ b/Persistence/Contexts/AppDbContext.cs
@@ -1,12 +1,24 @@
 using System;
+using System.Linq;
+using Microsoft.AspNetCore.Http;
 using Microsoft.EntityFrameworkCore;
 using ReleaseNotes_WebAPI.Domain.Models;
 using ReleaseNotes_WebAPI.Domain.Models.Auth;
+using ReleaseNotes_WebAPI.Security;
 
 namespace ReleaseNotes_WebAPI.Persistence.Contexts
 {
     public class AppDbContext : DbContext
     {
+        /**
+         * Truth table for query filter 
+         *
+         * 1 0 == 1 -> Entity is public, and user is not admin
+         * 0 1 == 1 -> Entity is not public, and user is admin
+         * 1 1 == 1 -> Entity is public, and user is admin
+         * 0 0 == 0 -> Entity is not public, and user is not admin
+         * 
+        */
         public DbSet<User> Users { get; set; }
         public DbSet<Role> Roles { get; set; }
         public DbSet<Article> Articles { get; set; }
@@ -16,9 +28,18 @@ namespace ReleaseNotes_WebAPI.Persistence.Contexts
         public DbSet<Product> Products { get; set; }
         public DbSet<ReleaseReleaseNote> ReleaseReleaseNotes { get; set; }
         public DbSet<AzureInformation> AzureInformations { get; set; }
+        private bool UserIsAdmin { get; }
 
-        public AppDbContext(DbContextOptions<AppDbContext> options) : base(options)
+        public AppDbContext(DbContextOptions<AppDbContext> options, IHttpContextAccessor accessor) : base(options)
         {
+            // By default no user is admin
+            UserIsAdmin = false;
+
+            // If the context is setting up for the first time. Don't run
+            if (accessor.HttpContext != null)
+            {
+                UserIsAdmin = ClaimsUtil.CheckIfUserIsAdmin(accessor);
+            }
         }
 
         protected override void OnModelCreating(ModelBuilder builder)
@@ -33,6 +54,17 @@ namespace ReleaseNotes_WebAPI.Persistence.Contexts
             builder.Entity<Release>().Property(r => r.Date).HasDefaultValue(DateTime.UtcNow);
             builder.Entity<ReleaseReleaseNote>().HasKey(
                 rrn => new {rrn.ReleaseId, rrn.ReleaseNoteId});
+            
+            // All entities that require extra security for isPublic
+            builder.Entity<Release>().HasQueryFilter(
+                r => r.IsPublic && !UserIsAdmin || !r.IsPublic && UserIsAdmin ||
+                     r.IsPublic && UserIsAdmin);
+            builder.Entity<ProductVersion>().HasQueryFilter(
+                pr => pr.IsPublic && !UserIsAdmin || !pr.IsPublic && UserIsAdmin ||
+                     pr.IsPublic && UserIsAdmin);
+            builder.Entity<ReleaseNote>().HasQueryFilter(
+                rn => rn.IsPublic && !UserIsAdmin || !rn.IsPublic && UserIsAdmin ||
+                     rn.IsPublic && UserIsAdmin);
         }
     }
 }

--- a/Persistence/Contexts/DatabaseSeed.cs
+++ b/Persistence/Contexts/DatabaseSeed.cs
@@ -100,7 +100,8 @@ namespace ReleaseNotes_WebAPI.Persistence.Contexts
                         Title = "Sletting av faktura", Ingress = "Det er nå mulig å slette faktura i faktura-systemet",
                         Description = htmlDummy6, WorkItemDescriptionHtml = htmlDummy1,
                         WorkItemTitle = "Test item please ignore",
-                        ClosedDate = new DateTime(2019, 11, 05, 10, 52, 02, 22)
+                        ClosedDate = new DateTime(2019, 11, 05, 10, 52, 02, 22),
+                        IsPublic = true
                     },
                     new ReleaseNote
                     {

--- a/Persistence/Contexts/DatabaseSeed.cs
+++ b/Persistence/Contexts/DatabaseSeed.cs
@@ -39,11 +39,11 @@ namespace ReleaseNotes_WebAPI.Persistence.Contexts
             {
                 var productVersions = new List<ProductVersion>
                 {
-                    new ProductVersion {Id = 100, ProductId = 100, Version = "1.0"},
+                    new ProductVersion {Id = 100, ProductId = 100, Version = "1.0", IsPublic = true},
                     new ProductVersion {Id = 101, ProductId = 100, Version = "2.0"},
                     new ProductVersion {Id = 105, ProductId = 100, Version = "2.1-Beta", IsPublic = false},
-                    new ProductVersion {Id = 102, ProductId = 101, Version = "3.0"},
-                    new ProductVersion {Id = 103, ProductId = 102, Version = "1.1"},
+                    new ProductVersion {Id = 102, ProductId = 101, Version = "3.0", IsPublic = true},
+                    new ProductVersion {Id = 103, ProductId = 102, Version = "1.1", IsPublic = true},
                     new ProductVersion {Id = 104, ProductId = 103, Version = "1.0"}
                 };
                 context.ProductVersions.AddRange(productVersions);

--- a/Persistence/Contexts/DatabaseSeed.cs
+++ b/Persistence/Contexts/DatabaseSeed.cs
@@ -37,7 +37,6 @@ namespace ReleaseNotes_WebAPI.Persistence.Contexts
             // If there are no ProductVersions
             if (!context.ProductVersions.Any())
             {
-                Console.WriteLine(context.Products);
                 var productVersions = new List<ProductVersion>
                 {
                     new ProductVersion {Id = 100, ProductId = 100, Version = "1.0"},

--- a/Security/ClaimsUtil.cs
+++ b/Security/ClaimsUtil.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Linq;
+using Microsoft.AspNetCore.Http;
+using ReleaseNotes_WebAPI.Domain.Models.Auth;
+
+namespace ReleaseNotes_WebAPI.Security
+{
+    public static class ClaimsUtil
+    {
+        public static bool CheckIfUserIsAdmin(IHttpContextAccessor accessor)
+        {
+            var claims = accessor.HttpContext.User.Claims.ToList();
+            if (claims.Any())
+            {
+                var roleClaim = claims.SingleOrDefault(
+                    claim => claim.Type == "http://schemas.microsoft.com/ws/2008/06/identity/claims/role");
+                if (roleClaim != null)
+                {
+                    if (roleClaim.Value == Enum.GetName(typeof(ERole), ERole.Administrator))
+                    {
+                        return true;
+                    } 
+                }
+            }
+            return false;
+        }
+    }
+}

--- a/Startup.cs
+++ b/Startup.cs
@@ -52,7 +52,7 @@ namespace ReleaseNotes_WebAPI
             var connectionString =
                 "host=" + host + ";port=" + port + ";database=" + db + ";username=" + user + ";password=" + passw + ";";
 
-            services.AddSingleton<IHttpContextAccessor, HttpContextAccessor>();
+            services.AddHttpContextAccessor();
             // ADDS DATABASE SERVICE
             // CONNECTS WEB-API TO DB
             services.AddDbContext<AppDbContext>(options => { options.UseNpgsql(connectionString); });

--- a/Startup.cs
+++ b/Startup.cs
@@ -4,6 +4,7 @@ using AutoMapper;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -51,6 +52,7 @@ namespace ReleaseNotes_WebAPI
             var connectionString =
                 "host=" + host + ";port=" + port + ";database=" + db + ";username=" + user + ";password=" + passw + ";";
 
+            services.AddSingleton<IHttpContextAccessor, HttpContextAccessor>();
             // ADDS DATABASE SERVICE
             // CONNECTS WEB-API TO DB
             services.AddDbContext<AppDbContext>(options => { options.UseNpgsql(connectionString); });

--- a/TestContainer/test/testReleaseNotes.js
+++ b/TestContainer/test/testReleaseNotes.js
@@ -7,7 +7,7 @@ chai.use(chaiHttp);
 
 var accessToken;
 const addressGet = "/api/releasenote";
-const addressGetSingle = "/api/releasenote/5";
+const ADDRESS_RELEASE_NOTE_1 = "/api/releasenote/1";
 const addressGetSingleFail = "/api/releasenote/23123";
 const addressPut = "/api/releasenote/100";
 const addressPutFail = "api/releasenote/123123125";
@@ -38,7 +38,7 @@ describe("Release notes GET", () => {
   before(() => init());
 
   // should return 200 OK and a array of release notes
-  it("GET | Get all release notes", (done) => {
+  it("GET | Get all release notes without logging in", (done) => {
     chai
       .request(process.env.APP_URL)
       .get(addressGet)
@@ -53,7 +53,7 @@ describe("Release notes GET", () => {
         expect(res.body[0].authorName).to.be.a("string").that.is.not.empty;
         expect(res.body[0].authorEmail).to.be.a("string").that.is.not.empty;
         expect(res.body[0].workItemTitle).to.be.a("string").that.is.not.empty;
-        expect(res.body[0].isPublic).to.equal(false);
+        expect(res.body[0].isPublic).to.equal(true);
         expect(res.body[0].workItemId).to.be.a("number");
         res.should.have.status(200);
         done();
@@ -61,10 +61,10 @@ describe("Release notes GET", () => {
   });
 
   // should return 200 OK and  a singe release note
-  it("GET | Successfully gets a single release note", (done) => {
+  it("GET | Successfully gets a single release note without logging in", (done) => {
     chai
       .request(process.env.APP_URL)
-      .get(addressGetSingle)
+      .get(ADDRESS_RELEASE_NOTE_1)
       .end((err, res) => {
         if (err) {
           done(err.response);
@@ -86,7 +86,7 @@ describe("Release notes GET", () => {
   it("GET | Successfully gets a single release note with associated releases", (done) => {
     chai
       .request(process.env.APP_URL)
-      .get(addressGetSingle)
+      .get(ADDRESS_RELEASE_NOTE_1)
       .query("includeReleases")
       .end((err, res) => {
         if (err) {
@@ -169,7 +169,7 @@ describe("Release notes DELETE", () => {
   it("DELETE | Tries to delete a release note without being logged in", (done) => {
     chai
       .request(process.env.APP_URL)
-      .delete(addressDelete)
+      .delete(ADDRESS_RELEASE_NOTE_1)
       .end((err) => {
         expect(err.should.have.status(401));
         done();
@@ -195,7 +195,7 @@ describe("Release notes DELETE", () => {
   it("DELETE | Should return a OK 200 and a copy of the deleted release note", (done) => {
     chai
       .request(process.env.APP_URL)
-      .delete(addressDelete)
+      .delete(ADDRESS_RELEASE_NOTE_1)
       .set("Content-Type", "application/json")
       .set("Authorization", "Bearer " + accessToken)
       .end((err, res) => {
@@ -213,7 +213,7 @@ describe("Release notes DELETE", () => {
   it("DELETE | Tries to delete a already deleted release note", (done) => {
     chai
       .request(process.env.APP_URL)
-      .delete(addressDelete)
+      .delete(ADDRESS_RELEASE_NOTE_1)
       .set("Content-Type", "application/json")
       .set("Authorization", "Bearer " + accessToken)
       .end((err) => {

--- a/TestContainer/test/testReleaseNotes.js
+++ b/TestContainer/test/testReleaseNotes.js
@@ -6,14 +6,10 @@ const { expect } = require("chai");
 chai.use(chaiHttp);
 
 var accessToken;
-const addressGet = "/api/releasenote";
-const ADDRESS_RELEASE_NOTE_1 = "/api/releasenote/1";
-const addressGetSingleFail = "/api/releasenote/23123";
-const addressPut = "/api/releasenote/100";
-const addressPutFail = "api/releasenote/123123125";
-const addressDelete = "/api/releasenote/5";
-const addressDeleteFail = "/api/releasenote/897324";
-const addressReleaseNote = "/api/releasenote";
+const ADDRESS_GET_RELEASE_NOTE = "/api/releasenote";
+const ADDRESS_GET_RELEASE_NOTE_1 = ADDRESS_GET_RELEASE_NOTE + "/1";
+const ADDRESS_GET_RELEASE_NOTE_NON_EXISTING =
+  ADDRESS_GET_RELEASE_NOTE + "/23123";
 
 const RELEASE_NOTE_WITHOUT_DESCRIPTION = {
   title: "Ny dag, ny release note",
@@ -41,7 +37,7 @@ describe("Release notes GET", () => {
   it("GET | Get all release notes without logging in", (done) => {
     chai
       .request(process.env.APP_URL)
-      .get(addressGet)
+      .get(ADDRESS_GET_RELEASE_NOTE)
       .end((err, res) => {
         if (err) {
           done(err);
@@ -64,7 +60,7 @@ describe("Release notes GET", () => {
   it("GET | Successfully gets a single release note without logging in", (done) => {
     chai
       .request(process.env.APP_URL)
-      .get(ADDRESS_RELEASE_NOTE_1)
+      .get(ADDRESS_GET_RELEASE_NOTE_1)
       .end((err, res) => {
         if (err) {
           done(err.response);
@@ -86,7 +82,7 @@ describe("Release notes GET", () => {
   it("GET | Successfully gets a single release note with associated releases", (done) => {
     chai
       .request(process.env.APP_URL)
-      .get(ADDRESS_RELEASE_NOTE_1)
+      .get(ADDRESS_GET_RELEASE_NOTE_1)
       .query("includeReleases")
       .end((err, res) => {
         if (err) {
@@ -109,7 +105,7 @@ describe("Release notes GET", () => {
   it("GET | requests a non-existant release note", (done) => {
     chai
       .request(process.env.APP_URL)
-      .get(addressGetSingleFail)
+      .get(ADDRESS_GET_RELEASE_NOTE_NON_EXISTING)
       .end((err, res) => {
         if (err) {
           done(err.response.text);
@@ -122,7 +118,7 @@ describe("Release notes GET", () => {
   it("GET | Get Release Notes from a set date interval", (done) => {
     chai
       .request(process.env.APP_URL)
-      .get(addressGet + CORRECT_DATE_FILTER)
+      .get(ADDRESS_GET_RELEASE_NOTE + CORRECT_DATE_FILTER)
       .end((err, res) => {
         if (err) {
           done(err.response.text);
@@ -150,7 +146,7 @@ describe("Release note POST", () => {
   it("POST | Tries to create release note without providing a description", (done) => {
     chai
       .request(process.env.APP_URL)
-      .post(addressReleaseNote)
+      .post(ADDRESS_GET_RELEASE_NOTE)
       .set("Content-Type", "application/json")
       .set("Authorization", "Bearer " + accessToken)
       .send(RELEASE_NOTE_WITHOUT_DESCRIPTION)
@@ -169,7 +165,7 @@ describe("Release notes DELETE", () => {
   it("DELETE | Tries to delete a release note without being logged in", (done) => {
     chai
       .request(process.env.APP_URL)
-      .delete(ADDRESS_RELEASE_NOTE_1)
+      .delete(ADDRESS_GET_RELEASE_NOTE_1)
       .end((err) => {
         expect(err.should.have.status(401));
         done();
@@ -181,7 +177,7 @@ describe("Release notes DELETE", () => {
   it("DELETE | Tries to delete a non-existant release note", (done) => {
     chai
       .request(process.env.APP_URL)
-      .delete(addressDeleteFail)
+      .delete(ADDRESS_GET_RELEASE_NOTE_NON_EXISTING)
       .set("Content-Type", "application/json")
       .set("Authorization", "Bearer " + accessToken)
       .end((err) => {
@@ -195,7 +191,7 @@ describe("Release notes DELETE", () => {
   it("DELETE | Should return a OK 200 and a copy of the deleted release note", (done) => {
     chai
       .request(process.env.APP_URL)
-      .delete(ADDRESS_RELEASE_NOTE_1)
+      .delete(ADDRESS_GET_RELEASE_NOTE_1)
       .set("Content-Type", "application/json")
       .set("Authorization", "Bearer " + accessToken)
       .end((err, res) => {
@@ -213,7 +209,7 @@ describe("Release notes DELETE", () => {
   it("DELETE | Tries to delete a already deleted release note", (done) => {
     chai
       .request(process.env.APP_URL)
-      .delete(ADDRESS_RELEASE_NOTE_1)
+      .delete(ADDRESS_GET_RELEASE_NOTE_1)
       .set("Content-Type", "application/json")
       .set("Authorization", "Bearer " + accessToken)
       .end((err) => {

--- a/TestContainer/test/testReleases.js
+++ b/TestContainer/test/testReleases.js
@@ -10,14 +10,14 @@ const TEST_RELEASE_1 = {
   ProductVersionId: 100,
   Title: "Release 2.5 - Vannkanon",
   IsPublic: false,
-  ReleaseNotesId: [1, 2]
+  ReleaseNotesId: [3, 2],
 };
 
 const TEST_RELEASE_2 = {
   ProductVersionId: 101,
   Title: "Release 2.6 - Vannkanon",
   IsPublic: true,
-  ReleaseNotesId: [1]
+  ReleaseNotesId: [3],
 };
 
 const TEST_RELEASE_NEW_RELEASE_NOTE = {
@@ -32,13 +32,13 @@ const TEST_RELEASE_NEW_RELEASE_NOTE = {
       WorkItemDescriptionHtml:
         '<div>Wireframe:</div><div><a href="https://confluence.uials.no/pages/viewpage.action?pageId=57378685">https://confluence.uials.no/pages/viewpage.action?pageId=57378685</a></div><div><br></div><div>ERD:</div><div><a href="https://confluence.uials.no/pages/viewpage.action?pageId=57377417">https://confluence.uials.no/pages/viewpage.action?pageId=57377417</a><br></div>',
       WorkitemId: 235,
-      WorkItemTitle: "Front-end: Oppdater state med azure-projects"
-    }
-  ]
+      WorkItemTitle: "Front-end: Oppdater state med azure-projects",
+    },
+  ],
 };
 
 const TEST_RELEASE_3 = {
-  IsPublic: false
+  IsPublic: false,
 };
 
 var accessToken;
@@ -58,31 +58,31 @@ describe("Releases POST", () => {
   before(() => init());
 
   // should return 401 unauth
-  it("CREATE | Tries to create a release without being logged in", done => {
+  it("CREATE | Tries to create a release without being logged in", (done) => {
     chai
       .request(process.env.APP_URL)
       .post(addressReleases)
       .send(TEST_RELEASE_1)
-      .end(err => {
+      .end((err) => {
         err.should.have.status(401);
         done();
       });
   });
 
   // should return a 401 unauth
-  it("PUT | Tries to update a release without being logged in", done => {
+  it("PUT | Tries to update a release without being logged in", (done) => {
     chai
       .request(process.env.APP_URL)
       .put(addressPut)
       .send(TEST_RELEASE_3)
-      .end(err => {
+      .end((err) => {
         err.should.have.status(401);
         done();
       });
   });
 
   // should return 200 OK
-  it("CREATE | Successfully creating a release", done => {
+  it("CREATE | Successfully creating a release", (done) => {
     chai
       .request(process.env.APP_URL)
       .post(addressReleases)
@@ -99,7 +99,7 @@ describe("Releases POST", () => {
   });
 
   // should return 200 OK
-  it("CREATE | Successfully creating a release with non existing Release Note", done => {
+  it("CREATE | Successfully creating a release with non existing Release Note", (done) => {
     chai
       .request(process.env.APP_URL)
       .post(addressReleases)
@@ -119,20 +119,20 @@ describe("Releases POST", () => {
   });
 
   // should return 400 Bad Request
-  it("CREATE | Tries to create a already created release", done => {
+  it("CREATE | Tries to create a already created release", (done) => {
     chai
       .request(process.env.APP_URL)
       .post(addressReleases)
       .set("Content-Type", "application/json")
       .set("Authorization", "Bearer " + accessToken)
       .send(TEST_RELEASE_1)
-      .end(err => {
+      .end((err) => {
         err.should.have.status(400);
         done();
       });
   });
 
-  it("PUT | Should return same object as trying to put ", done => {
+  it("PUT | Should return same object as trying to put ", (done) => {
     chai
       .request(process.env.APP_URL)
       .put(addressCheckAfterCreate)
@@ -155,7 +155,7 @@ describe("Releases POST", () => {
       });
   });
 
-  it("PUT | Should return non null fields", done => {
+  it("PUT | Should return non null fields", (done) => {
     chai
       .request(process.env.APP_URL)
       .put(addressCheckAfterCreate)
@@ -178,7 +178,7 @@ describe("Releases POST", () => {
       });
   });
 
-  it("PUT | Should handle unknown values", done => {
+  it("PUT | Should handle unknown values", (done) => {
     chai
       .request(process.env.APP_URL)
       .put(addressCheckAfterCreate)
@@ -205,7 +205,7 @@ describe("Releases POST", () => {
 describe("Releases GET", () => {
   before(() => init());
 
-  it("Should return all releases", done => {
+  it("Should return all releases", (done) => {
     chai
       .request(process.env.APP_URL)
       .get(addressReleases)
@@ -223,7 +223,7 @@ describe("Releases GET", () => {
       });
   });
 
-  it("GET | Attempting to get a non-existant release", done => {
+  it("GET | Attempting to get a non-existant release", (done) => {
     chai
       .request(process.env.APP_URL)
       .get(addressGetFail)
@@ -239,7 +239,7 @@ describe("Releases GET", () => {
   });
 
   // success case for getting a single release
-  it("GET | Should return a specific release", done => {
+  it("GET | Should return a specific release", (done) => {
     chai
       .request(process.env.APP_URL)
       .get(addressGet)
@@ -262,30 +262,30 @@ describe("Releases GET", () => {
 
 describe("Releases DELETE", () => {
   before(() => init());
-  it("DELETE | Tries to delete a release without logging in", done => {
+  it("DELETE | Tries to delete a release without logging in", (done) => {
     chai
       .request(process.env.APP_URL)
       .delete(addressDelete)
-      .end(err => {
+      .end((err) => {
         expect(err.should.have.status(401));
         done();
       });
   });
 
-  it("DELETE | Tries to delete a non-existant release", done => {
+  it("DELETE | Tries to delete a non-existant release", (done) => {
     chai
       .request(process.env.APP_URL)
       .delete(addressDeleteFail)
       .set("Content-Type", "application/json")
       .set("Authorization", "Bearer " + accessToken)
-      .end(err => {
+      .end((err) => {
         expect(err.should.have.status(400));
         done();
       });
   });
 
   // success case: deletes a release
-  it("DELETE | Should delete a release and return a copy of the deleted release", done => {
+  it("DELETE | Should delete a release and return a copy of the deleted release", (done) => {
     chai
       .request(process.env.APP_URL)
       .delete(addressCheckAfterCreate)
@@ -310,13 +310,13 @@ describe("Releases DELETE", () => {
   });
 
   // failure case: Tries to delete a already deleted release
-  it("DELETE | Tries to delete a already deleted release", done => {
+  it("DELETE | Tries to delete a already deleted release", (done) => {
     chai
       .request(process.env.APP_URL)
       .delete(addressCheckAfterCreate)
       .set("Content-Type", "application/json")
       .set("Authorization", "Bearer " + accessToken)
-      .end(err => {
+      .end((err) => {
         expect(err.should.have.status(400));
         done();
       });


### PR DESCRIPTION
God morgen, det som finnes bak dagens pull request er en ny måte å restrikere hva en bruker kan se fra våre offentlige endepunkter. Det som nå skjer hvis en bruker forespørr feks alle *Releases*, da blir kun de *Releases* som har `IsPublic: True` returnert.

Sånn som det er nå betyr det også at hvis en *ProductVersion* har `IsPublic: False`, og brukeren prøver å hente ut *Release* med `IsPublic: True`, så får man ikke tilbake informasjon om akkurat den *ProductVersion*. Dette gjelder også for *ReleaseNotes* som blir returnert sammen med *Releases*.

Akkurat nå er er denne filteringen lagt til for
- Releases.
- Release Notes
- ProductVersions. 

**Sannhetstabell:**
![image](https://user-images.githubusercontent.com/33400600/78767578-13edfb80-798b-11ea-8b8d-988f896916cf.png)
