### PR TITLE
Feature/MappableType

### DIFF
--- a/Controllers/MappableFieldsController.cs
+++ b/Controllers/MappableFieldsController.cs
@@ -21,14 +21,14 @@ namespace ReleaseNotes_WebAPI.Controllers
         
         [HttpGet]
         [Authorize(Roles = ("Administrator"))]
-        public async Task<IActionResult> ListAsync([FromQuery] bool mapped)
+        public async Task<IActionResult> ListAsync([FromQuery] bool mapped, [FromQuery] string type)
         {
             if (!ModelState.IsValid)
             {
                 return BadRequest(ModelState);
             }
             
-            var result = await _mappableService.ListAsync(mapped);
+            var result = await _mappableService.ListAsync(mapped, type);
 
             if (!result.Success)
             {
@@ -38,17 +38,17 @@ namespace ReleaseNotes_WebAPI.Controllers
             return Ok(result);
         }
         
-        [HttpPut("{id}")]
+        [HttpPut("{type}/{mappableField}")]
         [Authorize(Roles = ("Administrator"))]
         public async Task<IActionResult> UpdateReleaseNoteMappingAsync(
-            int id, [FromBody] UpdateReleaseNoteMappingResource resource)
+            [FromBody] UpdateReleaseNoteMappingResource resource, string type, string mappableField)
         {
             if (!ModelState.IsValid)
             {
                 return BadRequest(ModelState);
             }
             
-            var result = await _mappableService.UpdateReleaseNoteMappingAsync(resource, id);
+            var result = await _mappableService.UpdateReleaseNoteMappingAsync(resource, type, mappableField);
 
             if (!result.Success)
             {

--- a/Domain/Models/MappableType.cs
+++ b/Domain/Models/MappableType.cs
@@ -1,0 +1,8 @@
+﻿namespace ReleaseNotes_WebAPI.Domain.Models
+{
+    public class MappableType
+    {
+        public int Id { get; set; }
+        public string Name { get; set; }
+    }
+}

--- a/Domain/Models/ReleaseNoteMapping.cs
+++ b/Domain/Models/ReleaseNoteMapping.cs
@@ -2,8 +2,6 @@ namespace ReleaseNotes_WebAPI.Domain.Models
 {
     public class ReleaseNoteMapping
     {
-        //public int Id { get; set; }
-        
         public string AzureDevOpsField { get; set; }
         
         public int MappableFieldId { get; set; }
@@ -14,6 +12,5 @@ namespace ReleaseNotes_WebAPI.Domain.Models
         public int MappableTypeId { get; set; }
 
         public MappableType MappableType { get; set; }
-
     }
 }

--- a/Domain/Models/ReleaseNoteMapping.cs
+++ b/Domain/Models/ReleaseNoteMapping.cs
@@ -2,13 +2,18 @@ namespace ReleaseNotes_WebAPI.Domain.Models
 {
     public class ReleaseNoteMapping
     {
-        public int Id { get; set; }
+        //public int Id { get; set; }
         
         public string AzureDevOpsField { get; set; }
         
         public int MappableFieldId { get; set; }
         
         public MappableField MappableField { get; set; }
+        
+        
+        public int MappableTypeId { get; set; }
+
+        public MappableType MappableType { get; set; }
 
     }
 }

--- a/Domain/Repositories/IMappableRepository.cs
+++ b/Domain/Repositories/IMappableRepository.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using ReleaseNotes_WebAPI.Domain.Models;
@@ -8,8 +9,9 @@ namespace ReleaseNotes_WebAPI.Domain.Repositories
     public interface IMappableRepository
     {
         Task<IEnumerable<MappableField>> GetMappableFields();
-        Task<IEnumerable<ReleaseNoteMapping>> GetMappedFields();
-        Task<ReleaseNoteMapping> FindAsync(int id);
+        Task<IEnumerable<ReleaseNoteMapping>> GetMappedFields(string type);
+        Task<ReleaseNoteMapping> FindAsync(string type, string mappableField);
+
         void UpdateReleaseNoteMappingAsync(ReleaseNoteMapping existingMapping);
     }
 }

--- a/Domain/Services/IMappableService.cs
+++ b/Domain/Services/IMappableService.cs
@@ -9,8 +9,8 @@ namespace ReleaseNotes_WebAPI.Domain.Services
 {
     public interface IMappableService
     {
-        Task<MappingResponse> ListAsync(bool mapped);
+        Task<MappingResponse> ListAsync(bool mapped, string type);
         
-        Task<MappingResponse> UpdateReleaseNoteMappingAsync(UpdateReleaseNoteMappingResource resource, int id);
+        Task<MappingResponse> UpdateReleaseNoteMappingAsync(UpdateReleaseNoteMappingResource resource, string type, string mappableField);
     }
 }

--- a/Mapping/ModelToResourceProfile.cs
+++ b/Mapping/ModelToResourceProfile.cs
@@ -46,18 +46,29 @@ namespace ReleaseNotes_WebAPI.Mapping
                         opt.MapFrom(pv => pv.Product.Name + " " + pv.Version));
 
             CreateMap<Product, ProductResource>()
-                .ForMember(dest => dest.Versions, 
-                    opt => 
+                .ForMember(dest => dest.Versions,
+                    opt =>
                         opt.MapFrom(src => src.ProductVersions));
 
             CreateMap<ReleaseNote, ReleaseNoteResource>()
                 .ForMember(dest => dest.Releases,
                     opt =>
                         opt.MapFrom(src =>
-                            src.ReleaseReleaseNotes.Select(rrn => rrn.Release).Select(r => 
-                                new Release() {Date = r.Date, Id = r.Id,Title = r.Title,IsPublic = r.IsPublic,ProductVersion = r.ProductVersion})));
+                            src.ReleaseReleaseNotes.Select(rrn => rrn.Release).Select(r =>
+                                new Release()
+                                {
+                                    Date = r.Date, Id = r.Id, Title = r.Title, IsPublic = r.IsPublic,
+                                    ProductVersion = r.ProductVersion
+                                })));
+
             CreateMap<MappableField, MappableFieldsResource>();
-            CreateMap<ReleaseNoteMapping, ReleaseNoteMappingResource>();
+            CreateMap<ReleaseNoteMapping, ReleaseNoteMappingResource>()
+                .ForMember(dest => dest.MappableType,
+                    opt => 
+                        opt.MapFrom(src => src.MappableType.Name))
+                .ForMember(dest => dest.MappableField,
+                    opt => 
+                        opt.MapFrom(src => src.MappableField.Name));
         }
     }
 }

--- a/Persistence/Contexts/AppDbContext.cs
+++ b/Persistence/Contexts/AppDbContext.cs
@@ -20,6 +20,7 @@ namespace ReleaseNotes_WebAPI.Persistence.Contexts
          * 
         */
         public DbSet<User> Users { get; set; }
+
         public DbSet<Role> Roles { get; set; }
         public DbSet<Article> Articles { get; set; }
         public DbSet<Release> Releases { get; set; }
@@ -30,6 +31,8 @@ namespace ReleaseNotes_WebAPI.Persistence.Contexts
         public DbSet<AzureInformation> AzureInformations { get; set; }
         public DbSet<MappableField> MappableFields { get; set; }
         public DbSet<ReleaseNoteMapping> ReleaseNoteMappings { get; set; }
+        public DbSet<MappableType> MappableTypes { get; set; }
+
         private bool UserIsAdmin { get; }
 
         public AppDbContext(DbContextOptions<AppDbContext> options, IHttpContextAccessor accessor) : base(options)
@@ -47,23 +50,29 @@ namespace ReleaseNotes_WebAPI.Persistence.Contexts
         protected override void OnModelCreating(ModelBuilder builder)
         {
             base.OnModelCreating(builder);
-            
-            builder.Entity<UserRole>().HasKey(ur => new {ur.UserId, ur.RoleId});
+
+            // Generate default values
             builder.Entity<Article>().Property(a => a.Date).HasDefaultValue(DateTime.UtcNow);
             builder.Entity<Release>().Property(r => r.Date).HasDefaultValue(DateTime.UtcNow);
-            builder.Entity<ReleaseReleaseNote>().HasKey(
-                rrn => new {rrn.ReleaseId, rrn.ReleaseNoteId});
             
             // Generate primary key on add
             builder.Entity<AzureInformation>().Property(ai => ai.Id).ValueGeneratedOnAdd();
             builder.Entity<ReleaseNote>().Property(rn => rn.Id).ValueGeneratedOnAdd();
             builder.Entity<ProductVersion>().Property(pv => pv.Id).ValueGeneratedOnAdd();
             builder.Entity<MappableField>().Property(mf => mf.Id).ValueGeneratedOnAdd();
-            builder.Entity<ReleaseNoteMapping>().Property(rnm => rnm.Id).ValueGeneratedOnAdd();
-            
-            // Generate unique constraint
-            builder.Entity<ReleaseNoteMapping>().HasIndex(mf => mf.MappableFieldId).IsUnique();
+            builder.Entity<MappableType>().Property(mt => mt.Id).ValueGeneratedOnAdd();
 
+            // Generate unique constraint
+            //builder.Entity<ReleaseNoteMapping>().HasIndex(mf => mf.MappableFieldId).IsUnique();
+            builder.Entity<MappableType>().HasIndex(mt => mt.Name).IsUnique();
+
+            // Generate key types
+            builder.Entity<UserRole>().HasKey(ur => new {ur.UserId, ur.RoleId});
+            builder.Entity<ReleaseNoteMapping>()
+                .HasKey(rnm => new {rnm.MappableFieldId, rnm.MappableTypeId});
+            builder.Entity<ReleaseReleaseNote>().HasKey(
+                rrn => new {rrn.ReleaseId, rrn.ReleaseNoteId});
+            
             // All entities that require extra security for isPublic
             builder.Entity<Release>().HasQueryFilter(
                 r => !(!r.IsPublic && !UserIsAdmin));

--- a/Persistence/Contexts/AppDbContext.cs
+++ b/Persistence/Contexts/AppDbContext.cs
@@ -63,7 +63,6 @@ namespace ReleaseNotes_WebAPI.Persistence.Contexts
             builder.Entity<MappableType>().Property(mt => mt.Id).ValueGeneratedOnAdd();
 
             // Generate unique constraint
-            //builder.Entity<ReleaseNoteMapping>().HasIndex(mf => mf.MappableFieldId).IsUnique();
             builder.Entity<MappableType>().HasIndex(mt => mt.Name).IsUnique();
 
             // Generate key types

--- a/Persistence/Contexts/DatabaseSeed.cs
+++ b/Persistence/Contexts/DatabaseSeed.cs
@@ -283,7 +283,10 @@ namespace ReleaseNotes_WebAPI.Persistence.Contexts
                     {
                         Email = "admin@ungspiller.no", Password = passwordHasher.HashPassword("12345678"),
                         AzureInformation = new AzureInformation
-                            {Id = 123,UserId = "test.testovitch@testnes.no", Pat = "123123asdasd", Organization = "ReleaseNotesSystem"}
+                        {
+                            Id = 123, UserId = "test.testovitch@testnes.no", Pat = "123123asdasd",
+                            Organization = "ReleaseNotesSystem"
+                        }
                     },
                     new User
                     {
@@ -300,7 +303,18 @@ namespace ReleaseNotes_WebAPI.Persistence.Contexts
                 context.Users.AddRange(users);
                 context.SaveChanges();
             }
-            
+
+            if (!context.MappableTypes.Any())
+            {
+                var types = new List<MappableType>
+                {
+                    new MappableType {Name = "task"},
+                    new MappableType {Name = "bug"},
+                };
+                context.MappableTypes.AddRange(types);
+                context.SaveChanges();
+            }
+
             // If there are no mappings
             if (!context.MappableFields.Any())
             {
@@ -316,17 +330,23 @@ namespace ReleaseNotes_WebAPI.Persistence.Contexts
                     new MappableField {Name = "WorkItemTitle"},
                     new MappableField {Name = "ClosedDate"}
                 };
-                
+
                 context.MappableFields.AddRange(fields);
                 if (!context.ReleaseNoteMappings.Any())
                 {
                     var mappings = new List<ReleaseNoteMapping>();
-                    foreach (var mappableField in fields)
+                    foreach (var mappableType in context.MappableTypes.ToList())
                     {
-                        mappings.Add(new ReleaseNoteMapping {MappableField = mappableField});
+                        foreach (var mappableField in fields)
+                        {
+                            mappings.Add(new ReleaseNoteMapping
+                                {MappableField = mappableField, MappableType = mappableType});
+                        }
                     }
+
                     context.AddRange(mappings);
                 }
+
                 context.SaveChanges();
             }
         }

--- a/Persistence/Contexts/DatabaseSeed.cs
+++ b/Persistence/Contexts/DatabaseSeed.cs
@@ -285,7 +285,7 @@ namespace ReleaseNotes_WebAPI.Persistence.Contexts
                         AzureInformation = new AzureInformation
                         {
                             Id = 123, UserId = "test.testovitch@testnes.no", Pat = "123123asdasd",
-                            Organization = "ReleaseNotesSystem"
+                            Organization = "ReleaseNoteSystem"
                         }
                     },
                     new User

--- a/Persistence/Repositories/MappableRepository.cs
+++ b/Persistence/Repositories/MappableRepository.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -10,29 +11,38 @@ namespace ReleaseNotes_WebAPI.Persistence.Repositories
 {
     public class MappableRepository : BaseRepository, IMappableRepository
     {
-        
-        
         public MappableRepository(AppDbContext context) : base(context)
         {
         }
-        
+
         public async Task<IEnumerable<MappableField>> GetMappableFields()
         {
-           return await _context.MappableFields.ToListAsync();
+            var query = _context.MappableFields.AsNoTracking();
+            return await query.ToListAsync();
         }
 
-        public async Task<IEnumerable<ReleaseNoteMapping>> GetMappedFields()
+        public async Task<IEnumerable<ReleaseNoteMapping>> GetMappedFields(string type)
         {
-            return await _context.ReleaseNoteMappings.Include(
-                rrm => rrm.MappableField).ToListAsync();
+            var query = _context.ReleaseNoteMappings.AsTracking();
+            if (!string.IsNullOrWhiteSpace(type))
+            {
+                query = query.Where(m => m.MappableType.Name.ToUpper() == type.ToUpper());
+            }
+
+            return await query
+                .Include(rnm => rnm.MappableField)
+                .Include(rnm => rnm.MappableType)
+                .ToListAsync();
         }
 
-        public async Task<ReleaseNoteMapping> FindAsync(int id)
+        public async Task<ReleaseNoteMapping> FindAsync(string type, string mappableField)
         {
             return await _context.ReleaseNoteMappings
                 .Include(rnm => rnm.MappableField)
-                .Where(rnm => rnm.Id == id)
-                .SingleOrDefaultAsync();
+                .Include(rnm => rnm.MappableType)
+                .SingleOrDefaultAsync(rnm => 
+                    rnm.MappableField.Name.ToUpper() == mappableField.ToUpper() &&
+                    rnm.MappableType.Name.ToUpper() == type.ToUpper());
         }
 
         public void UpdateReleaseNoteMappingAsync(ReleaseNoteMapping existingMapping)

--- a/Resources/ReleaseNoteMappingResource.cs
+++ b/Resources/ReleaseNoteMappingResource.cs
@@ -4,7 +4,6 @@ namespace ReleaseNotes_WebAPI.Resources
 {
     public class ReleaseNoteMappingResource
     {
-        public int Id { get; set; }
         public string AzureDevOpsField { get; set; }
         public string MappableField { get; set; }
         public string MappableType { get; set; }

--- a/Resources/ReleaseNoteMappingResource.cs
+++ b/Resources/ReleaseNoteMappingResource.cs
@@ -5,11 +5,8 @@ namespace ReleaseNotes_WebAPI.Resources
     public class ReleaseNoteMappingResource
     {
         public int Id { get; set; }
-        
         public string AzureDevOpsField { get; set; }
-        
-        public int MappableFieldId { get; set; }
-        
-        public MappableField MappableField { get; set; }
+        public string MappableField { get; set; }
+        public string MappableType { get; set; }
     }
 }


### PR DESCRIPTION
AB#324 AB#325
Implement MappableType (også kjent som WorkItemType) table

- Implementert queryParameter "type" i `GetMappedFields` endpoint
- Fjerna ID fra ReleaseNoteMapping. PK en no en composite key av  `MappableType `og `MappableField`. Sjå https://confluence.uials.no/plugins/gliffy/editor.action?inline=false&pageId=57377417&name=ER-D&ceoid=57377417&key=RNS&lastPage=%2Fpages%2Fviewpage.action%3FpageId%3D57377417&macroId=
- I staden for å oppdatere på /{id}, oppdatera du på /{MappableType }/{MappableField} i `UpdateMapping` endpoint
- En ReleaseNoteMapping entitet fra serveren ser også derfor no slik ut: 
![bilde](https://user-images.githubusercontent.com/35314375/79890606-08c1b380-8400-11ea-9342-3cb708331e02.png)

